### PR TITLE
[bitnami/mlflow] Azure Storage Support in helm chart

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 1.5.7
+version: 1.5.8

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 1.5.11
+version: 1.5.12

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 1.5.10
+version: 1.5.11

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 1.5.8
+version: 1.5.9

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 1.5.9
+version: 1.5.10

--- a/bitnami/mlflow/README.md
+++ b/bitnami/mlflow/README.md
@@ -471,6 +471,20 @@ The command deploys mlflow on the Kubernetes cluster in the default configuratio
 | `externalGCS.existingSecretKey`      | Key in the existing secret containing the application credentials (required when useCredentialsInSecret is true)          | `""`    |
 | `externalGCS.serveArtifacts`         | Whether artifact serving is enabled                                                                                       | `true`  |
 
+### External Azure Blob Storage parameters
+
+| Name                                            | Description                                                                                                                   | Value    |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `externalAzureBlob.storageAccount`              | Azure Blob Storage account name. Activate azure artifact storage if set,                                                      | `""`     |
+| `externalAzureBlob.accessKey`                   | Azure Blob Storage access key. Optional if connectionString is set                                                            | `""`     |
+| `externalAzureBlob.connectionString`            | Azure Blob Storage connection string. Optional if accessKey is set.                                                           | `""`     |
+| `externalAzureBlob.containerName`               | Azure Blob Storage container name                                                                                             | `mlflow` |
+| `externalAzureBlob.useCredentialsInSecret`      | Whether to read the Azure Blob Storage credentials from a secret                                                              | `false`  |
+| `externalAzureBlob.existingSecret`              | Name of an existing secret key containing the Azure Blob Storage credentials (required when useCredentialsInSecret is true)   | `""`     |
+| `externalAzureBlob.existingAccessKeyKey`        | Key in the existing secret containing the Azure Blob Storage access key (required when useCredentialsInSecret is true)        | `""`     |
+| `externalAzureBlob.existingConnectionStringKey` | Key in the existing secret containing the Azure Blob Storage connection string (required when useCredentialsInSecret is true) | `""`     |
+| `externalAzureBlob.serveArtifacts`              | Whether artifact serving is enabled                                                                                           | `true`   |
+
 The MLflow chart supports three different ways to load your files in the `run` deployment. In order of priority, they are:
 
 1. Existing config map

--- a/bitnami/mlflow/README.md
+++ b/bitnami/mlflow/README.md
@@ -479,10 +479,14 @@ The command deploys mlflow on the Kubernetes cluster in the default configuratio
 | `externalAzureBlob.accessKey`                   | Azure Blob Storage access key. Optional if connectionString is set                                                            | `""`     |
 | `externalAzureBlob.connectionString`            | Azure Blob Storage connection string. Optional if accessKey is set.                                                           | `""`     |
 | `externalAzureBlob.containerName`               | Azure Blob Storage container name                                                                                             | `mlflow` |
+| `externalAzureBlob.clientId`                    | Azure Blob Storage client ID                                                                                                  | `""`     |
+| `externalAzureBlob.tenantId`                    | Azure Blob Storage tenant ID                                                                                                  | `""`     |
+| `externalAzureBlob.clientSecret`                | Azure Blob Storage client secret                                                                                              | `""`     |
 | `externalAzureBlob.useCredentialsInSecret`      | Whether to read the Azure Blob Storage credentials from a secret                                                              | `false`  |
 | `externalAzureBlob.existingSecret`              | Name of an existing secret key containing the Azure Blob Storage credentials (required when useCredentialsInSecret is true)   | `""`     |
 | `externalAzureBlob.existingAccessKeyKey`        | Key in the existing secret containing the Azure Blob Storage access key (required when useCredentialsInSecret is true)        | `""`     |
 | `externalAzureBlob.existingConnectionStringKey` | Key in the existing secret containing the Azure Blob Storage connection string (required when useCredentialsInSecret is true) | `""`     |
+| `externalAzureBlob.clientSecretKey`             | Key in the existing secret containing the Azure Blob Storage client secret (required when useCredentialsInSecret is true)     | `""`     |
 | `externalAzureBlob.serveArtifacts`              | Whether artifact serving is enabled                                                                                           | `true`   |
 
 The MLflow chart supports three different ways to load your files in the `run` deployment. In order of priority, they are:

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -658,11 +658,20 @@ Return the S3 secret access key inside the secret
 Return whether GCS is enabled
 */}}
 {{- define "mlflow.v0.gcs.enabled" -}}
-    {{- if and (not .Values.minio.enabled) (not .Values.externalS3.host) .Values.externalGCS.bucket -}}
+    {{- if and (not .Values.minio.enabled) (not .Values.externalS3.host) (not .Values.externalAzureBlob.storageAccount) .Values.externalGCS.bucket -}}
         {{- true }}
     {{- end -}}
 {{- end -}}
 
+
+{{/*
+Return whether Azure Blob is enabled
+*/}}
+{{- define "mlflow.v0.azureBlob.enabled" -}}
+    {{- if and (not .Values.minio.enabled) (not .Values.externalS3.host) (not .Values.externalGCS.bucket) .Values.externalAzureBlob.storageAccount -}}
+        {{- true }}
+    {{- end -}}
+{{- end -}}
 
 {{/*
 Return the proper git image name

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -143,6 +143,8 @@ spec:
             - --artifacts-destination=s3://{{ include "mlflow.v0.s3.bucket" . }}
             {{- else if (include "mlflow.v0.gcs.enabled" .) }}
             - --artifacts-destination=gs://{{ .Values.externalGCS.bucket }}
+            {{- else if (include "mlflow.v0.azureBlob.enabled" .) }}
+            - --artifacts-destination=wasbs://{{ .Values.externalAzureBlob.containerName }}@{{ .Values.externalAzureBlob.storageAccount }}.blob.core.windows.net
             {{- else }}
             - --artifacts-destination={{ .Values.tracking.persistence.mountPath }}/mlartifacts
             {{- end }}
@@ -151,6 +153,9 @@ spec:
             - --no-serve-artifacts
             {{- else if and (not .Values.externalGCS.serveArtifacts) (include "mlflow.v0.gcs.enabled" .) }}
             - --default-artifact-root=gs://{{ .Values.externalGCS.bucket }}
+            - --no-serve-artifacts
+            {{- else if and (not .Values.externalAzureBlob.serveArtifacts) (include "mlflow.v0.azureBlob.enabled" .) }}
+            - --default-artifact-root=wasbs://{{ .Values.externalAzureBlob.containerName }}@{{ .Values.externalAzureBlob.storageAccount }}.blob.core.windows.net
             - --no-serve-artifacts
             {{ else }}
             - --serve-artifacts
@@ -200,6 +205,27 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /bitnami/gcs/key.json
             {{- end }}
+
+            {{- if (include "mlflow.v0.azureBlob.enabled" .) }}
+            {{- if .Values.externalAzureBlob.useCredentialsInSecret }}
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalAzureBlob.existingSecret }}
+                  key: {{ .Values.externalAzureBlob.existingConnectionStringKey }}
+            - name: AZURE_STORAGE_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalAzureBlob.existingSecret }}
+                  key: {{ .Values.externalAzureBlob.existingAccessKeyKey }}
+            {{- else }}
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              value: {{ .Values.externalAzureBlob.connectionString }}
+            - name: AZURE_STORAGE_ACCESS_KEY
+              value: {{ .Values.externalAzureBlob.accessKey }}
+            {{- end }}
+            {{- end }}
+            -
             {{- if .Values.externalGCS.googleCloudProject }}
             - name: GOOGLE_CLOUD_PROJECT
               value: {{ .Values.externalGCS.googleCloudProject }}

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -218,11 +218,22 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.externalAzureBlob.existingSecret }}
                   key: {{ .Values.externalAzureBlob.existingAccessKeyKey }}
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalAzureBlob.existingSecret }}
+                  key: {{ .Values.externalAzureBlob.clientSecretKey }}
             {{- else }}
             - name: AZURE_STORAGE_CONNECTION_STRING
               value: {{ .Values.externalAzureBlob.connectionString }}
             - name: AZURE_STORAGE_ACCESS_KEY
               value: {{ .Values.externalAzureBlob.accessKey }}
+            - name: AZURE_CLIENT_ID
+              value: {{ .Values.externalAzureBlob.clientId }}
+            - name: AZURE_TENANT_ID
+              value: {{ .Values.externalAzureBlob.tenantId }}
+            - name: AZURE_CLIENT_SECRET
+              value: {{ .Values.externalAzureBlob.clientSecret }}
             {{- end }}
             {{- end }}
             -

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -228,16 +228,26 @@ spec:
                   name: {{ .Values.externalAzureBlob.existingSecret }}
                   key: {{ .Values.externalAzureBlob.clientSecretKey }}
             {{- else }}
+            {{- if .Values.externalAzureBlob.connectionString }}
             - name: AZURE_STORAGE_CONNECTION_STRING
               value: {{ .Values.externalAzureBlob.connectionString }}
+            {{- end }}
+            {{- if .Values.externalAzureBlob.accessKey }}
             - name: AZURE_STORAGE_ACCESS_KEY
               value: {{ .Values.externalAzureBlob.accessKey }}
+            {{- end }}
+            {{- if .Values.externalAzureBlob.clientId }}
             - name: AZURE_CLIENT_ID
               value: {{ .Values.externalAzureBlob.clientId }}
+            {{- end }}
+            {{- if .Values.externalAzureBlob.tenantId }}
             - name: AZURE_TENANT_ID
               value: {{ .Values.externalAzureBlob.tenantId }}
+            {{- end }}
+            {{- if .Values.externalAzureBlob.clientSecret }}
             - name: AZURE_CLIENT_SECRET
               value: {{ .Values.externalAzureBlob.clientSecret }}
+            {{- end }}
             {{- end }}
             {{- end }}
 

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -202,8 +202,8 @@ spec:
             - name: MLFLOW_S3_ENDPOINT_URL
               value: {{ printf "%s://%s:%v" (include "mlflow.v0.s3.protocol" .) (include "mlflow.v0.s3.host" .) (include "mlflow.v0.s3.port" .) | quote }}
             {{- end }}
-            -
             {{- if (include "mlflow.v0.gcs.enabled" .) }}
+
             {{- if .Values.externalGCS.useCredentialsInSecret }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /bitnami/gcs/key.json

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -182,6 +182,7 @@ spec:
                   name: {{ include "mlflow.v0.database.secretName" . }}
                   key: {{ include "mlflow.v0.database.passwordKey" . | quote }}
             {{- end }}
+
             {{- if (include "mlflow.v0.s3.enabled" .) }}
             {{- if .Values.externalS3.useCredentialsInSecret }}
             - name: AWS_ACCESS_KEY_ID
@@ -196,10 +197,12 @@ spec:
                   key: {{ include "mlflow.v0.s3.secretAccessKeyKey" . | quote }}
             {{- end }}
             {{- end }}
+
             {{- if (include "mlflow.v0.s3.enabled" .) }}
             - name: MLFLOW_S3_ENDPOINT_URL
               value: {{ printf "%s://%s:%v" (include "mlflow.v0.s3.protocol" .) (include "mlflow.v0.s3.host" .) (include "mlflow.v0.s3.port" .) | quote }}
             {{- end }}
+            -
             {{- if (include "mlflow.v0.gcs.enabled" .) }}
             {{- if .Values.externalGCS.useCredentialsInSecret }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -237,12 +240,12 @@ spec:
               value: {{ .Values.externalAzureBlob.clientSecret }}
             {{- end }}
             {{- end }}
-            -
+
             {{- if .Values.externalGCS.googleCloudProject }}
             - name: GOOGLE_CLOUD_PROJECT
               value: {{ .Values.externalGCS.googleCloudProject }}
             {{- end }}
-            {{- end }}
+
             {{- if .Values.tracking.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.tracking.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -205,6 +205,7 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /bitnami/gcs/key.json
             {{- end }}
+            {{- end }}
 
             {{- if (include "mlflow.v0.azureBlob.enabled" .) }}
             {{- if .Values.externalAzureBlob.useCredentialsInSecret }}

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -1447,10 +1447,14 @@ externalGCS:
 ## @param externalAzureBlob.accessKey Azure Blob Storage access key. Optional if connectionString is set
 ## @param externalAzureBlob.connectionString Azure Blob Storage connection string. Optional if accessKey is set.
 ## @param externalAzureBlob.containerName Azure Blob Storage container name
+## @param externalAzureBlob.clientId Azure Blob Storage client ID
+## @param externalAzureBlob.tenantId Azure Blob Storage tenant ID
+## @param externalAzureBlob.clientSecret Azure Blob Storage client secret
 ## @param externalAzureBlob.useCredentialsInSecret Whether to read the Azure Blob Storage credentials from a secret
 ## @param externalAzureBlob.existingSecret Name of an existing secret key containing the Azure Blob Storage credentials (required when useCredentialsInSecret is true)
 ## @param externalAzureBlob.existingAccessKeyKey Key in the existing secret containing the Azure Blob Storage access key (required when useCredentialsInSecret is true)
 ## @param externalAzureBlob.existingConnectionStringKey Key in the existing secret containing the Azure Blob Storage connection string (required when useCredentialsInSecret is true)
+## @param externalAzureBlob.clientSecretKey Key in the existing secret containing the Azure Blob Storage client secret (required when useCredentialsInSecret is true)
 ## @param externalAzureBlob.serveArtifacts Whether artifact serving is enabled
 ##
 externalAzureBlob:
@@ -1458,8 +1462,12 @@ externalAzureBlob:
   accessKey: ""
   connectionString: ""
   containerName: "mlflow"
+  clientId: ""
+  tenantId: ""
+  clientSecret: ""
   useCredentialsInSecret: false
   existingSecret: ""
   existingAccessKeyKey: ""
   existingConnectionStringKey: ""
+  clientSecretKey: ""
   serveArtifacts: true

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -1439,3 +1439,27 @@ externalGCS:
   existingSecret: ""
   existingSecretKey: ""
   serveArtifacts: true
+
+## @section External Azure Blob Storage parameters
+## All of these values are only used when minio.enabled is set to false and externalS3 is not configured (host is empty)
+## and externalGCS is not configured (bucket is empty).
+## @param externalAzureBlob.storageAccount Azure Blob Storage account name. Activate azure artifact storage if set,
+## @param externalAzureBlob.accessKey Azure Blob Storage access key. Optional if connectionString is set
+## @param externalAzureBlob.connectionString Azure Blob Storage connection string. Optional if accessKey is set.
+## @param externalAzureBlob.containerName Azure Blob Storage container name
+## @param externalAzureBlob.useCredentialsInSecret Whether to read the Azure Blob Storage credentials from a secret
+## @param externalAzureBlob.existingSecret Name of an existing secret key containing the Azure Blob Storage credentials (required when useCredentialsInSecret is true)
+## @param externalAzureBlob.existingAccessKeyKey Key in the existing secret containing the Azure Blob Storage access key (required when useCredentialsInSecret is true)
+## @param externalAzureBlob.existingConnectionStringKey Key in the existing secret containing the Azure Blob Storage connection string (required when useCredentialsInSecret is true)
+## @param externalAzureBlob.serveArtifacts Whether artifact serving is enabled
+##
+externalAzureBlob:
+  storageAccount: ""
+  accessKey: ""
+  connectionString: ""
+  containerName: "mlflow"
+  useCredentialsInSecret: false
+  existingSecret: ""
+  existingAccessKeyKey: ""
+  existingConnectionStringKey: ""
+  serveArtifacts: true


### PR DESCRIPTION
### Description of the change

The PR adds the missing configuration options for the Azure Storage Account in the MLFlow helm chart.

### Benefits

As explained in the ticket #28569, Azure Storage is supported by MLFlow, but it is not currently possible to configure it via the Helm chart. With this change Azure Blob Storage can be configured to store the artefacts of MLFlow.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #28569

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
